### PR TITLE
added ability to inject msg id during sendToWait

### DIFF
--- a/RadioHead/RHReliableDatagram.cpp
+++ b/RadioHead/RHReliableDatagram.cpp
@@ -45,10 +45,17 @@ uint8_t RHReliableDatagram::retries()
 }
 
 ////////////////////////////////////////////////////////////////////
-bool RHReliableDatagram::sendtoWait(uint8_t* buf, uint8_t len, uint8_t address)
+bool RHReliableDatagram::sendtoWait(uint8_t* buf, uint8_t len, uint8_t address, uint8_t* id)
 {
     // Assemble the message
-    uint8_t thisSequenceNumber = ++_lastSequenceNumber;
+    uint8_t thisSequenceNumber;
+	
+	// If any, put ID defined by user (e.g. between turn on/off cycles when sequenceNo should be saved in EEPROM)
+	if (id != NULL)
+		thisSequenceNumber = *id;
+	else
+		thisSequenceNumber = ++_lastSequenceNumber;
+	
     uint8_t retries = 0;
     while (retries++ <= _retries)
     {

--- a/RadioHead/RHReliableDatagram.h
+++ b/RadioHead/RHReliableDatagram.h
@@ -116,8 +116,10 @@ public:
     /// \param[in] address The address to send the message to.
     /// \param[in] buf Pointer to the binary message to send
     /// \param[in] len Number of octets to send
+	/// \param[in] id If present and not NULL, the referenced uint8_t will be set to the ID. Useful when
+	///	message id should be presisted in EEPROM between board on/off cycles
     /// \return true if the message was transmitted and an acknowledgement was received.
-    bool sendtoWait(uint8_t* buf, uint8_t len, uint8_t address);
+    bool sendtoWait(uint8_t* buf, uint8_t len, uint8_t address, uint8_t* id = NULL);
 
     /// If there is a valid message available for this node, send an acknowledgement to the SRC
     /// address (blocking until this is complete), then copy the message to buf and return true


### PR DESCRIPTION
I've used this trick to make my application (on/off cycles of the board) working. IMO it is worth to point that _lastSequenceNumber (placed in volatile memory) has to be up-to-date (e.g. saved in eeprom) to proceed transmissions via reliable datagram.